### PR TITLE
bugfix/accurics_remediation_14849155352159205 - Auto Generated Pull Request From Accurics

### DIFF
--- a/aws/s3_bucket.tf
+++ b/aws/s3_bucket.tf
@@ -2,4 +2,9 @@ resource "aws_s3_bucket" "tenable_cs_demo_s3_bucket" {
   bucket = "tenablecsdemos3bucket"
   acl    = "public-read"
   tags   = var.default_tags
+
+  versioning {
+    enabled    = true
+    mfa_delete = true
+  }
 }


### PR DESCRIPTION
Perform the steps below to enable MFA delete on an S3 bucket.

Note:
-You cannot enable MFA Delete using the AWS Management Console. You must use the AWS CLI or API.
-You must use your 'root' account to enable MFA Delete on S3 buckets.

**From Command line:**

1. Run the s3api put-bucket-versioning command


aws s3api put-bucket-versioning --profile my-root-profile --bucket Bucket_Name --versioning-configuration Status=Enabled,MFADelete=Enabled --mfa "arn:aws:iam::aws_account_id:mfa/root-account-mfa-device passcode"
.