### PR TITLE
bugfix/accurics_remediation_6144387784373346 - Auto Generated Pull Request From Accurics

### DIFF
--- a/aws/s3_bucket.tf
+++ b/aws/s3_bucket.tf
@@ -2,4 +2,13 @@ resource "aws_s3_bucket" "tenable_cs_demo_s3_bucket" {
   bucket = "tenablecsdemos3bucket"
   acl    = "public-read"
   tags   = var.default_tags
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm     = "aws:kms"
+        kms_master_key_id = "<master_kms_key_id>"
+      }
+    }
+  }
 }


### PR DESCRIPTION
In AWS Console -
1. Sign in to the AWS console and go to the S3 console. 
2. Choose the bucket you wish to edit.
3. Select the Properties tab.
4. Under Default encryption, select Edit.
5. For key type, select AWS Key Management Service key (SSE-KMS).
6. Select Enter AWS KMS key ARN and set the value to the key you wish to use.
7. Select Save changes.

In Terraform -
For current AWS Provider versions:
1. For each aws_s3_bucket resource, add an aws_s3_bucket_server_side_encryption_configuration resource.
2. Set the bucket field to the aws_s3_bucket for which this policy should be applied.
3. Create a rule block and set the rule.sse_algorithm field to aws:kms.
4. Set the rule.kms_master_key_id field to a valid KMS key ARN.

For AWS Provider versions prior to 3.x (deprecated):
1. In the aws_s3_bucket resource, add a server_side_encryption_configuration block.
2. Set the server_side_encryption_configuration.sse_algorithm field to aws:kms.
3. Set the server_side_encryption_configuration.kms_master_key_id field to a valid KMS key ARN.

References:
https://docs.aws.amazon.com/AmazonS3/latest/userguide/serv-side-encryption.html
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#server_side_encryption_configuration
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration